### PR TITLE
README: add example using oasis cli to sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ following steps:
 
 2. Fork this repository.
 
-3. Use the [`oasis-registry`] command to generate a new signed statement. The
-   command must be run in the directory where you cloned this repository. This
-   will require the use of an Oasis Core signer (all the same signers and
-   configuration flags are supported). For example, using a file-based signer:
+3. Use the [`oasis-cli`] (minimum version 0.7.1) command to generate a new signed statement.
+   For example:
 
    ```bash
-   oasis-registry entity update \
-     --signer.dir /localhostdir/entity \
-     /path/to/entity-metadata.json
+   oasis account entity metadata-update \
+      --account my-entity-account \
+      --registry-dir /path/to/metadata-registry \
+      /path/to/entity-metadata.json
    ```
 
    This will create (or update) the registry entry.
@@ -65,7 +64,7 @@ following steps:
    happens the updated entity metadata will be available for queries.
 
 <!-- markdownlint-disable line-length -->
-[`oasis-registry`]: https://github.com/oasisprotocol/metadata-registry-tools
+[`oasis-cli`]: https://docs.oasis.io/general/manage-tokens/cli/
 [ADR 0001]: docs/adr/0001-entity-metadata.md
 <!-- markdownlint-enable line-length -->
 


### PR DESCRIPTION
Wait with merging until a CLI release exists which includes: https://github.com/oasisprotocol/cli/pull/170 

Could maybe even remove the oasis-registry example altogether, not sure, decided to keep ti for now.